### PR TITLE
Set urllib3==1.25.10 since requests 2.23.0 depends on urllib3!=1.25.0…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ chardet==3.0.4
 configparser==5.0.0
 idna==2.9
 requests==2.23.0
-urllib3==1.26.5
+urllib3==1.25.10


### PR DESCRIPTION
Suggest downgrading urlib3 because installing the requirements results with the output below. urllib3==1.25.10 Seems to work fine, just like urllib3==1.25.9 seems to have been working in the past.

$ pypy3 -m pip install -r requirements.txt 
Collecting certifi==2020.4.5.1
  Downloading certifi-2020.4.5.1-py2.py3-none-any.whl (157 kB)
     |████████████████████████████████| 157 kB 3.4 MB/s            
Collecting chardet==3.0.4
  Using cached chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting configparser==5.0.0
  Downloading configparser-5.0.0-py3-none-any.whl (22 kB)
Collecting idna==2.9
  Downloading idna-2.9-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 14.9 MB/s            
Collecting requests==2.23.0
  Downloading requests-2.23.0-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 10.5 MB/s            
Collecting urllib3==1.26.5
  Downloading urllib3-1.26.5-py2.py3-none-any.whl (138 kB)
     |████████████████████████████████| 138 kB 17.7 MB/s            
INFO: pip is looking at multiple versions of idna to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of configparser to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of chardet to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of certifi to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 5) and urllib3==1.26.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.23.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies